### PR TITLE
fix: table show has no column named category

### DIFF
--- a/resources/lib/storesqlite.py
+++ b/resources/lib/storesqlite.py
@@ -776,7 +776,6 @@ CREATE INDEX "index_2" ON film ("showid", "title" COLLATE NOCASE);
 -- ----------------------------
 --  Indexes structure for table show
 -- ----------------------------
-CREATE INDEX "category" ON show ("category");
 CREATE INDEX "search" ON show ("search");
 CREATE INDEX "combined_1" ON show ("channelid", "search");
 CREATE INDEX "combined_2" ON show ("channelid", "show");


### PR DESCRIPTION
the column doesn't exist and the plugin crashes on the db creation. this
will result in the updater process is not able to get a lock on the
table.

    ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
     - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
    Error Type: <class 'sqlite3.OperationalError'>
    Error Contents: table show has no column named category
    Traceback (most recent call last):
      File "/home/kodi/.kodi/addons/plugin.video.mediathekview/service.py", line 88, in <module>
	service.Init()
      File "/home/kodi/.kodi/addons/plugin.video.mediathekview/service.py", line 56, in Init
	self.updater.Init()
      File "/home/kodi/.kodi/addons/plugin.video.mediathekview/resources/lib/updater.py", line 57, in Init
	self.db.Init()
      File "/home/kodi/.kodi/addons/plugin.video.mediathekview/resources/lib/store.py", line 28, in Init
	self.db.Init( reset )
      File "/home/kodi/.kodi/addons/plugin.video.mediathekview/resources/lib/storesqlite.py", line 38, in Init
	self._handle_database_initialization()
      File "/home/kodi/.kodi/addons/plugin.video.mediathekview/resources/lib/storesqlite.py", line 783, in _handle_database_initialization
	""" )
    OperationalError: table show has no column named category
    -->End of Python script error report<--