### PR TITLE
Make the update check interval a setting parameter #140, #131

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -62,6 +62,10 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Neuigkeit berechnet ab"
 
+msgctxt "#30118"
+msgid "Up-to-Date check interval [sec]"
+msgstr "Nach Updates suchen alle [sec]"
+
 msgctxt "#30171"
 msgid "Aired Date"
 msgstr "Sendedatum"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -62,6 +62,10 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Recent calculated by"
 
+msgctxt "#30118"
+msgid "Up-to-Date check interval [sec]"
+msgstr "Up-to-Date check interval [sec]"
+
 msgctxt "#30171"
 msgid "Aired Date"
 msgstr "Aired Date"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -62,6 +62,10 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Novità calcolate con"
 
+msgctxt "#30119"
+msgid "Default Sort Method for film list"
+msgstr "Ordinamento predefinito per l'elenco dei film"
+
 msgctxt "#30171"
 msgid "Aired Date"
 msgstr "Data di Trasmissione"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -62,6 +62,10 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Novità calcolate con"
 
+msgctxt "#30118"
+msgid "Up-to-Date check interval [sec]"
+msgstr "intervallo di controllo [sec]"
+
 msgctxt "#30119"
 msgid "Default Sort Method for film list"
 msgstr "Ordinamento predefinito per l'elenco dei film"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -66,10 +66,6 @@ msgctxt "#30118"
 msgid "Up-to-Date check interval [sec]"
 msgstr "intervallo di controllo [sec]"
 
-msgctxt "#30119"
-msgid "Default Sort Method for film list"
-msgstr "Ordinamento predefinito per l'elenco dei film"
-
 msgctxt "#30171"
 msgid "Aired Date"
 msgstr "Data di Trasmissione"

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -73,7 +73,7 @@ class MediathekViewService(KodiService):
                 self.settings.save_update_instance(self.monitor.instance_id)
                 self.updater.update(False)
             # Sleep/wait for abort for 60 seconds
-            if self.monitor.wait_for_abort(15):
+            if self.monitor.wait_for_abort(self.settings.updateCheckInterval):
                 # Abort was requested while waiting. We should exit
                 break
         self.info('Shutting down... (instance id: {})',

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -2,7 +2,7 @@
 """
 The addon settings module
 
-Copyright 2017-2018, Leo Moll and Dominik SchlÃ¶sser
+Copyright 2017-2018, Leo Moll and Dominik Schlösser
 Licensed under MIT License
 """
 
@@ -38,6 +38,7 @@ class Settings(object):
         self.maxresults = int(addon.getSetting('maxresults'))
         self.maxage = int(addon.getSetting('maxage')) * 86400
         self.recentmode = int(addon.getSetting('recentmode'))
+        self.updateCheckInterval = int(addon.getSetting('updateCheckInterval')
         # database
         self.type = int(addon.getSetting('dbtype'))
         self.host = addon.getSetting('dbhost')

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -2,7 +2,7 @@
 """
 The addon settings module
 
-Copyright 2017-2018, Leo Moll and Dominik Schl�sser
+Copyright 2017-2018, Leo Moll and Dominik Schlösser
 Licensed under MIT License
 """
 

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -2,7 +2,7 @@
 """
 The addon settings module
 
-Copyright 2017-2018, Leo Moll and Dominik Schlösser
+Copyright 2017-2018, Leo Moll and Dominik Schlï¿½sser
 Licensed under MIT License
 """
 
@@ -38,7 +38,7 @@ class Settings(object):
         self.maxresults = int(addon.getSetting('maxresults'))
         self.maxage = int(addon.getSetting('maxage')) * 86400
         self.recentmode = int(addon.getSetting('recentmode'))
-        self.updateCheckInterval = int(addon.getSetting('updateCheckInterval')
+        self.updateCheckInterval = int(addon.getSetting('updateCheckInterval'))
         # database
         self.type = int(addon.getSetting('dbtype'))
         self.host = addon.getSetting('dbhost')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,6 +9,7 @@
 		<setting id="maxresults"		type="slider"	label="30115"	default="1000"	range="100,100,3000" option="int"	/>
 		<setting id="maxage"			type="slider"	label="30116"	default="2"		range="1,30" option="int"			/>
 		<setting id="recentmode"		type="enum"		label="30117"	default="0"		lvalues="30171|30172"				/>
+		<setting id="updateCheckInterval" type="slider"	label="30118"	default="15"	range="15,600" option="int"			/>
 	</category>
 	<category label="30002">
 		<setting id="dbtype"			type="enum"		label="30210"	default="0"	lvalues="30221|30222"					/>


### PR DESCRIPTION
This PR should address the issues 140 and 131.
It allows the user to define the check interval for DB updates in the setting windows.
New setting was added in settings and translation.
The defualt of 15s stays untouched but maybe changed by end user.