### PR TITLE
check database file on startup reset db if needed

### DIFF
--- a/resources/lib/storesqlite.py
+++ b/resources/lib/storesqlite.py
@@ -114,12 +114,12 @@ class StoreSQLite(object):
             # check if DB is ready or broken
             cursor = self.conn.cursor()
             cursor.execute('SELECT * FROM `status` LIMIT 1')
-            result = cursor.fetchall()
+            cursor.fetchall()
             cursor.close()
         except sqlite3.DatabaseError as err:
             self.logger.error('Error on first query: {}. trying to fully reset the Database...', err)
             return self.init(reset=True, convert=convert)
-            
+
         # that is a bit dangerous :-) but faaaast
         self.conn.execute('pragma synchronous=off')
         self.conn.create_function('UNIX_TIMESTAMP', 0, get_unix_timestamp)

--- a/resources/lib/storesqlite.py
+++ b/resources/lib/storesqlite.py
@@ -60,7 +60,7 @@ class StoreSQLite(object):
         self.ft_show = None
         self.ft_showid = None
 
-    def init(self, reset=False, convert=False):
+    def init(self, reset=False, convert=False, failedCount = 0):
         """
         Startup of the database system
 
@@ -117,8 +117,13 @@ class StoreSQLite(object):
             cursor.fetchall()
             cursor.close()
         except sqlite3.DatabaseError as err:
-            self.logger.error('Error on first query: {}. trying to fully reset the Database...', err)
-            return self.init(reset=True, convert=convert)
+            failedCount += 1
+            if (failedCount > 3):
+                self.logger.error('Failed to restore database, please uninstall plugin, delete user profile and reinstall')
+                raise err
+            
+            self.logger.error('Error on first query: {}. trying to fully reset the Database...trying {} times', err, failedCount)
+            return self.init(reset=True, convert=convert, failedCount=failedCount)
 
         # that is a bit dangerous :-) but faaaast
         self.conn.execute('pragma synchronous=off')

--- a/resources/lib/storesqlite.py
+++ b/resources/lib/storesqlite.py
@@ -121,10 +121,8 @@ class StoreSQLite(object):
             if (failedCount > 3):
                 self.logger.error('Failed to restore database, please uninstall plugin, delete user profile and reinstall')
                 raise err
-            
             self.logger.error('Error on first query: {}. trying to fully reset the Database...trying {} times', err, failedCount)
             return self.init(reset=True, convert=convert, failedCount=failedCount)
-
         # that is a bit dangerous :-) but faaaast
         self.conn.execute('pragma synchronous=off')
         self.conn.create_function('UNIX_TIMESTAMP', 0, get_unix_timestamp)


### PR DESCRIPTION
Added another try catch in the DB Sqllite init section to detect broken DB files and trigger reload of a new file in case broken. This should solve issue #132 and at least requires no more manual interaction in case of broken DB files.