### PR TITLE
Add DateAdded as sort method, setting for default sort, added to plot

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -62,13 +62,6 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Neuigkeit berechnet ab"
 
-<<<<<<< Upstream, based on origin/SortByDateadded
-=======
-msgctxt "#30118"
-msgid "Up-to-Date check interval [sec]"
-msgstr "Nach Updates suchen alle [sec]"
-
->>>>>>> 066084e Add DateAdded as sort method, setting for default sort, added to plot
 msgctxt "#30119"
 msgid "Default Sort Method for film list"
 msgstr "Standard Sortierung der Filmliste"
@@ -83,11 +76,11 @@ msgstr "Sendedatum"
 
 msgctxt "#30122"
 msgid "Sort by added"
-msgstr "Hinzugefügt"
+msgstr "Hinzugefï¿½gt"
 
 msgctxt "#30123"
 msgid "Sort by size"
-msgstr "Dateigröße"
+msgstr "Dateigrï¿½ï¿½e"
 
 msgctxt "#30124"
 msgid "Sort by duration"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -62,6 +62,13 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Neuigkeit berechnet ab"
 
+<<<<<<< Upstream, based on origin/SortByDateadded
+=======
+msgctxt "#30118"
+msgid "Up-to-Date check interval [sec]"
+msgstr "Nach Updates suchen alle [sec]"
+
+>>>>>>> 066084e Add DateAdded as sort method, setting for default sort, added to plot
 msgctxt "#30119"
 msgid "Default Sort Method for film list"
 msgstr "Standard Sortierung der Filmliste"
@@ -456,3 +463,7 @@ msgstr "Fehler beim Abspielen"
 msgctxt "#30989"
 msgid "Cannot retrieve Movie Information"
 msgstr "Es war nicht möglich die Sendung zu finden"
+
+msgctxt "#30990"
+msgid "Airdate: [COLOR chartreuse]{0:s}[/COLOR][CR][CR]"
+msgstr "Ausgestrahlt: [COLOR chartreuse]{0:s}[/COLOR][CR][CR]"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -62,6 +62,30 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Neuigkeit berechnet ab"
 
+msgctxt "#30119"
+msgid "Default Sort Method for film list"
+msgstr "Standard Sortierung der Filmliste"
+
+msgctxt "#30120"
+msgid "Sort by title"
+msgstr "Titel"
+
+msgctxt "#30121"
+msgid "Sort by date"
+msgstr "Sendedatum"
+
+msgctxt "#30122"
+msgid "Sort by added"
+msgstr "Hinzugefügt"
+
+msgctxt "#30123"
+msgid "Sort by size"
+msgstr "Dateigröße"
+
+msgctxt "#30124"
+msgid "Sort by duration"
+msgstr "Dauer"
+
 msgctxt "#30171"
 msgid "Aired Date"
 msgstr "Sendedatum"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -76,11 +76,11 @@ msgstr "Sendedatum"
 
 msgctxt "#30122"
 msgid "Sort by added"
-msgstr "Hinzugef�gt"
+msgstr "Hinzugefügt"
 
 msgctxt "#30123"
 msgid "Sort by size"
-msgstr "Dateigr��e"
+msgstr "Dateigröße"
 
 msgctxt "#30124"
 msgid "Sort by duration"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -456,3 +456,7 @@ msgstr "Play Error"
 msgctxt "#30989"
 msgid "Cannot retrieve Movie Information"
 msgstr "Cannot retrieve Movie Information"
+
+msgctxt "#30990"
+msgid "Airdate: [COLOR chartreuse]{0:s}[/COLOR][CR][CR]"
+msgstr "Airdate: [COLOR chartreuse]{0:s}[/COLOR][CR][CR]"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -62,6 +62,30 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Recent calculated by"
 
+msgctxt "#30119"
+msgid "Default Sort Method for film list"
+msgstr "Default sort for film list"
+
+msgctxt "#30120"
+msgid "Sort by title"
+msgstr "Title"
+
+msgctxt "#30121"
+msgid "Sort by date"
+msgstr "Date"
+
+msgctxt "#30122"
+msgid "Sort by added"
+msgstr "Added Date"
+
+msgctxt "#30123"
+msgid "Sort by size"
+msgstr "Size"
+
+msgctxt "#30124"
+msgid "Sort by duration"
+msgstr "Duration"
+
 msgctxt "#30171"
 msgid "Aired Date"
 msgstr "Aired Date"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -457,3 +457,7 @@ msgstr "Errore di Riproduzione"
 msgctxt "#30989"
 msgid "Cannot retrieve Movie Information"
 msgstr "Non è stato possibile trovare il film"
+
+msgctxt "#30990"
+msgid "Airdate: [COLOR chartreuse]{0:s}[/COLOR][CR][CR]"
+msgstr "In onda: [COLOR chartreuse]{0:s}[/COLOR][CR][CR]"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -62,6 +62,30 @@ msgctxt "#30117"
 msgid "Recent calculated by"
 msgstr "Novità calcolate con"
 
+msgctxt "#30119"
+msgid "Default Sort Method for film list"
+msgstr "Ordinamento predefinito per l'elenco dei film"
+
+msgctxt "#30120"
+msgid "Sort by title"
+msgstr "Ordina per titolo"
+
+msgctxt "#30121"
+msgid "Sort by date"
+msgstr "Ordinare per data"
+
+msgctxt "#30122"
+msgid "Sort by added"
+msgstr "Entrata"
+
+msgctxt "#30123"
+msgid "Sort by size"
+msgstr "Ordina per dimensione"
+
+msgctxt "#30124"
+msgid "Sort by duration"
+msgstr "Ordina per durata"
+
 msgctxt "#30171"
 msgid "Aired Date"
 msgstr "Data di Trasmissione"

--- a/resources/lib/filmui.py
+++ b/resources/lib/filmui.py
@@ -57,7 +57,7 @@ class FilmUI(Film):
             allSortMethods[0] = allSortMethods[self.settings.filmSortMethod]
             allSortMethods[self.settings.filmSortMethod]=method
             self.sortmethods = allSortMethods
-            
+
         self.showshows = False
         self.showchannels = False
 

--- a/resources/lib/filmui.py
+++ b/resources/lib/filmui.py
@@ -9,6 +9,7 @@ Licensed under MIT License
 import os
 
 # pylint: disable=import-error
+import xbmc
 import xbmcgui
 import xbmcplugin
 
@@ -40,12 +41,23 @@ class FilmUI(Film):
         self.plugin = plugin
         self.handle = plugin.addon_handle
         self.settings = Settings()
-        self.sortmethods = sortmethods if sortmethods is not None else [
+        # define sortmethod for films
+        # all av. sort method and put the default sortmethod on first place to be used by UI
+        allSortMethods = [
             xbmcplugin.SORT_METHOD_TITLE,
             xbmcplugin.SORT_METHOD_DATE,
-            xbmcplugin.SORT_METHOD_DURATION,
-            xbmcplugin.SORT_METHOD_SIZE
+            xbmcplugin.SORT_METHOD_DATEADDED,
+            xbmcplugin.SORT_METHOD_SIZE,
+            xbmcplugin.SORT_METHOD_DURATION
         ]
+        if sortmethods is not None:
+            self.sortmethods = sortmethods
+        else:
+            method = allSortMethods[0]
+            allSortMethods[0] = allSortMethods[self.settings.filmSortMethod]
+            allSortMethods[self.settings.filmSortMethod]=method
+            self.sortmethods = allSortMethods
+            
         self.showshows = False
         self.showchannels = False
 
@@ -214,8 +226,9 @@ class FilmUI(Film):
             if airedstring[:4] != '1970':
                 info_labels['date'] = airedstring[8:10] + '-' + \
                     airedstring[5:7] + '-' + airedstring[:4]
-                info_labels['aired'] = airedstring
+                info_labels['aired'] = airedstring[:10]
                 info_labels['dateadded'] = airedstring
+                info_labels['plot'] = self.plugin.language(30990).format(airedstring) + info_labels['plot']
 
         icon = os.path.join(
             self.plugin.path,

--- a/resources/lib/filmui.py
+++ b/resources/lib/filmui.py
@@ -9,7 +9,6 @@ Licensed under MIT License
 import os
 
 # pylint: disable=import-error
-import xbmc
 import xbmcgui
 import xbmcplugin
 

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -38,6 +38,7 @@ class Settings(object):
         self.maxresults = int(addon.getSetting('maxresults'))
         self.maxage = int(addon.getSetting('maxage')) * 86400
         self.recentmode = int(addon.getSetting('recentmode'))
+        self.filmSortMethod = int(addon.getSetting('filmuisortmethod'))
         # database
         self.type = int(addon.getSetting('dbtype'))
         self.host = addon.getSetting('dbhost')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
 		<setting id="autosub"			type="bool"		label="30111"	default="false"										/>
 		<setting id="nofuture"			type="bool"		label="30112"	default="true"										/>
 		<setting id="minlength"			type="slider"	label="30113"	default="0"		range="0,30"						/>
+		<setting id="filmuisortmethod"  type="enum"		label="30119"	default="0"		lvalues="30120|30121|30122|30123|30124"	/>
 		<setting id="groupshows"		type="bool"		label="30114"	default="true"										/>
 		<setting id="maxresults"		type="slider"	label="30115"	default="1000"	range="100,100,3000" option="int"	/>
 		<setting id="maxage"			type="slider"	label="30116"	default="2"		range="1,30" option="int"			/>


### PR DESCRIPTION
allow sorting by dateAdded which is a timestamp (inc. hours) and enables sorting by date and hours as per request in #95 
Adding airdate (timesetamp) to the plot which is the only way to show this information in Kodi at the moment.
allow to set default sorting via settings #71
