### PR TITLE
Mysql native password#136

### DIFF
--- a/resources/lib/storemysql.py
+++ b/resources/lib/storemysql.py
@@ -66,13 +66,21 @@ class StoreMySQL(object):
         if reset:
             self.logger.warn('Reset not supported')
         try:
-            self.conn = mysql.connector.connect(
-                host=self.settings.host,
-                port=self.settings.port,
-                user=self.settings.user,
-                password=self.settings.password,
-                auth_plugin = 'mysql_native_password'
-            )
+            try:
+                self.conn = mysql.connector.connect(
+                    host=self.settings.host,
+                    port=self.settings.port,
+                    user=self.settings.user,
+                    password=self.settings.password
+                )
+            except:
+                self.conn = mysql.connector.connect(
+                    host=self.settings.host,
+                    port=self.settings.port,
+                    user=self.settings.user,
+                    password=self.settings.password,
+                    auth_plugin = 'mysql_native_password'
+                )
             try:
                 cursor = self.conn.cursor()
                 cursor.execute('SELECT VERSION()')

--- a/resources/lib/storemysql.py
+++ b/resources/lib/storemysql.py
@@ -66,6 +66,7 @@ class StoreMySQL(object):
         if reset:
             self.logger.warn('Reset not supported')
         try:
+            # TODO Kodi 19 - we can update to mysql connector which supports auth_plugin parameter
             try:
                 self.conn = mysql.connector.connect(
                     host=self.settings.host,

--- a/resources/lib/storemysql.py
+++ b/resources/lib/storemysql.py
@@ -70,7 +70,8 @@ class StoreMySQL(object):
                 host=self.settings.host,
                 port=self.settings.port,
                 user=self.settings.user,
-                password=self.settings.password
+                password=self.settings.password,
+                auth_plugin = 'mysql_native_password'
             )
             try:
                 cursor = self.conn.cursor()

--- a/resources/lib/storemysql.py
+++ b/resources/lib/storemysql.py
@@ -74,7 +74,7 @@ class StoreMySQL(object):
                     user=self.settings.user,
                     password=self.settings.password
                 )
-            except:
+            except Exception:
                 self.conn = mysql.connector.connect(
                     host=self.settings.host,
                     port=self.settings.port,


### PR DESCRIPTION
MySql connector for mvupdate (standalone) requires additional parameter native password.
In Kodi this parameter is not required / supported due to the used mysql connector.
We can not update mysql connector for Kodi becaus a new version is only av. in Kodi 19.
Therefore we will have to live with this fix to do some try catch.
This will solve issue #136 