### PR TITLE
show error message for 8 sec

### DIFF
--- a/resources/lib/kodi/kodiui.py
+++ b/resources/lib/kodi/kodiui.py
@@ -123,7 +123,7 @@ class KodiUI(object):
         self.show_notification(
             heading, message, xbmcgui.NOTIFICATION_WARNING, time, sound)
 
-    def show_error(self, heading, message, time=5000, sound=True):
+    def show_error(self, heading, message, time=8000, sound=True):
         """
         Shows an error notification to the user
 


### PR DESCRIPTION
Lange Fehlermeldungen kann man nur schlecht lesen da der Inhalt durch das Bild läuft bzw die Zeit haben muss durch das Bild zu laufen #147 