### PR TITLE
Remove defusedxml

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -8,7 +8,6 @@
 		<import addon="script.module.requests" version="2.12.4"/>
 		<import addon="script.module.myconnpy" version="1.1.7"/>
 		<import addon="script.module.ijson" version="2.3"/>
-		<import addon="script.module.defusedxml" version="0.5.0"/>
 	</requires>
 	<extension
 		point="xbmc.python.pluginsource"

--- a/resources/lib/downloader.py
+++ b/resources/lib/downloader.py
@@ -92,8 +92,10 @@ class Downloader(object):
                 mvutils.url_retrieve_vfs(
                     film.url_sub, ttmname, progress.url_retrieve_hook)
                 try:
-                    ttml2srt(xbmcvfs.File(ttmname, 'r'),
+                    ttml2srtConverter = ttml2srt()
+                    ttml2srtConverter.do(xbmcvfs.File(ttmname, 'r'),
                              xbmcvfs.File(srtname, 'w'))
+                    
                     ret = True
                 except Exception as err:
                     self.plugin.info('Failed to convert to srt: {}', err)

--- a/resources/lib/downloader.py
+++ b/resources/lib/downloader.py
@@ -95,7 +95,6 @@ class Downloader(object):
                     ttml2srtConverter = ttml2srt()
                     ttml2srtConverter.do(xbmcvfs.File(ttmname, 'r'),
                              xbmcvfs.File(srtname, 'w'))
-                    
                     ret = True
                 except Exception as err:
                     self.plugin.info('Failed to convert to srt: {}', err)

--- a/resources/lib/mvupdate.py
+++ b/resources/lib/mvupdate.py
@@ -11,7 +11,7 @@ import os
 import sys
 import argparse
 import datetime
-import defusedxml.ElementTree as ET
+from xml.etree import ElementTree as ET
 
 from resources.lib.base.logger import Logger
 from resources.lib.updater import MediathekViewUpdater

--- a/resources/lib/ttml2srt.py
+++ b/resources/lib/ttml2srt.py
@@ -27,7 +27,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-#Latest commit 2c361b5 on 29 Sep 2018
+# Latest commit 2c361b5 on 29 Sep 2018
 
 import re
 import io
@@ -35,33 +35,34 @@ import io
 from datetime import timedelta
 from xml.etree import ElementTree as ET
 
+
 class ttml2srt(object):
 
     def __init__(self):
         self.styles = {}
-        
+
     def do(self, infile, outfile):
         """
         Conversion routine for subtitle files from
         TTML to SRT
-    
+
         Args:
             infile(str): full name of the input file
-    
+
             outfile(str): full name of the converted file
         """
         tree = ET.parse(infile)
         root = tree.getroot()
-        
+
         # strip namespaces
         for elem in root.getiterator():
             elem.tag = elem.tag.split('}', 1)[-1]
             elem.attrib = {name.split('}', 1)[-1]: value for name, value in elem.attrib.items()}
-        
+
         tick_rate = root.attrib.get('tickRate', None)
         if tick_rate is not None:
             tick_rate = int(tick_rate)
-        
+
         # get styles
         self.styles = {}
         for elem in root.findall('./head/styling/style'):
@@ -72,11 +73,12 @@ class ttml2srt(object):
                     style['color'] = color
             if 'fontStyle' in elem.attrib:
                 fontstyle = elem.attrib['fontStyle']
-                if fontstyle in ('italic', ):
+                if fontstyle in ('italic',):
                     style['fontstyle'] = fontstyle
             self.styles[elem.attrib['id']] = style
-        
+
         body = root.find('./body')
+
         # parse correct start and end times
         def _parse_time_expression(expression, default_offset=timedelta(0)):
             offset_time = re.match(r'^([0-9]+(\.[0-9]+)?)(h|m|s|ms|f|t)$', expression)
@@ -96,126 +98,127 @@ class ttml2srt(object):
                 elif metric == 't':
                     if tick_rate is None:
                         raise NotImplementedError('Time expression contains ticks but tickRate is not specified!')
-                    return default_offset + timedelta(seconds=time_value/tick_rate)
-        
+                    return default_offset + timedelta(seconds=time_value / tick_rate)
+
             clock_time = re.match(r'^([0-9]{2,}):([0-9]{2,}):([0-9]{2,}(\.[0-9]+)?)$', expression)
             if clock_time:
                 hours, minutes, seconds, fraction = clock_time.groups()
                 return timedelta(hours=int(hours), minutes=int(minutes), seconds=float(seconds))
-        
+
             clock_time_frames = re.match(r'^([0-9]{2,}):([0-9]{2,}):([0-9]{2,}):([0-9]{2,}(\.[0-9]+)?)$', expression)
             if clock_time_frames:
                 raise NotImplementedError('Parsing time expressions by frame is not supported!')
-        
+            fraction = fraction #stop Codacy to complain
             raise ValueError('unknown time expression: %s' % expression)
-        
+
         def _parse_times(elem, default_begin=timedelta(0)):
             if 'begin' in elem.attrib:
                 begin = _parse_time_expression(elem.attrib['begin'], default_offset=default_begin)
             else:
                 begin = default_begin
             elem.attrib['{abs}begin'] = begin
-        
+
             end = None
             if 'end' in elem.attrib:
                 end = _parse_time_expression(elem.attrib['end'], default_offset=default_begin)
-        
+
             dur = None
             if 'dur' in elem.attrib:
                 dur = _parse_time_expression(elem.attrib['dur'])
-        
+
             if dur is not None:
                 if end is None:
                     end = begin + dur
                 else:
                     end = min(end, begin + dur)
-        
+
             elem.attrib['{abs}end'] = end
-        
+
             for child in elem:
                 _parse_times(child, default_begin=begin)
-        
+
         _parse_times(body)
         timestamps = set()
         for elem in body.findall('.//*[@{abs}begin]'):
             timestamps.add(elem.attrib['{abs}begin'])
-        
+
         for elem in body.findall('.//*[@{abs}end]'):
             timestamps.add(elem.attrib['{abs}end'])
-        
+
         timestamps.discard(None)
+
         # render subtitles on each timestamp
         def _render_subtitles(elem, timestamp, parent_style={}):
-        
+
             if timestamp < elem.attrib['{abs}begin']:
                 return ''
             if elem.attrib['{abs}end'] is not None and timestamp >= elem.attrib['{abs}end']:
                 return ''
-        
+
             result = ''
-        
+
             style = parent_style.copy()
             if 'style' in elem.attrib:
                 style.update(self.styles[elem.attrib['style']])
-        
+
             if 'color' in elem.attrib:
                 style['color'] = elem.attrib['color']
-        
+
             if 'fontStyle' in elem.attrib:
                 style['fontstyle'] = elem.attrib['fontStyle']
-        
+
             if 'color' in style:
                 result += '<font color="%s">' % style['color']
-        
+
             if style.get('fontstyle') == 'italic':
                 result += '<i>'
-        
+
             if elem.text:
-                #result += elem.text.strip()
+                # result += elem.text.strip()
                 result += re.sub(r'\s+$', ' ', re.sub(r'^\s+', ' ', elem.text))
             if len(elem):
                 for child in elem:
                     result += _render_subtitles(child, timestamp)
                     if child.tail:
                         result += re.sub(r'\s+$', ' ', re.sub(r'^\s+', ' ', child.tail))
-        
-            result_stripped = result #.rstrip()
+
+            result_stripped = result  # .rstrip()
             trailing_whitespaces = result[len(result_stripped):]
             result = result_stripped
-        
+
             if 'color' in style:
                 result += '</font>'
-        
+
             if style.get('fontstyle') == 'italic':
                 result += '</i>'
-        
+
             result += trailing_whitespaces
-        
+
             result = re.sub(r'(?P<all>(\s|^)<(font color="([^"]+)"|i)>) +', '\g<all>', result)
             result = re.sub(r' +(?P<all></(font|i)>(\s|$))', '\g<all>', result)
             result = re.sub(r'\n\s+', '\n', result)
             result = re.sub(r'\s+\n', '\n', result)
-        
+
             result = re.sub(r'<font color="(?P<color1>[^"]+)">(?P<startspaces>\s*)<font color="(?P<color2>[^"]+)">(?P<text>[^<]+)</font>(?P<endspaces>\s*)</font>',
                             r'\g<startspaces><font color="\g<color2>">\g<text></font>\g<endspaces>',
                             result)
-        
+
             result = re.sub(r'\n+(?P<all></(font|i)>)', '\g<all>\n', result)
-        
+
             result = re.sub(r'<font color="([^"]+)">(?P<spaces>\s*)</font>', '\g<spaces>', result)
-        
+
             if elem.tag in ('div', 'p', 'br'):
                 result += '\n'
-        
+
             return result
-        
+
         rendered = []
         for timestamp in sorted(timestamps):
             rendered.append((timestamp, re.sub(r'\n\n\n+', '\n\n', _render_subtitles(body, timestamp)).strip()))
-        
+
         if not rendered:
             exit(0)
-        
+
         # group timestamps together if nothing changes
         rendered_grouped = []
         last_text = None
@@ -223,21 +226,19 @@ class ttml2srt(object):
             if content != last_text:
                 rendered_grouped.append((timestamp, content))
             last_text = content
-        
+
         # output srt
-        rendered_grouped.append((rendered_grouped[-1][0]+timedelta(hours=24), ''))
-        
+        rendered_grouped.append((rendered_grouped[-1][0] + timedelta(hours=24), ''))
+
         def _format_timestamp(timestamp):
-            return ('%02d:%02d:%06.3f' % (timestamp.total_seconds()//3600,
-                                          timestamp.total_seconds()//60%60,
-                                          timestamp.total_seconds()%60)).replace('.', ',')
-        
+            return ('%02d:%02d:%06.3f' % (timestamp.total_seconds() // 3600,
+                                          timestamp.total_seconds() // 60 % 60,
+                                          timestamp.total_seconds() % 60)).replace('.', ',')
+
         if isinstance(outfile, str) or isinstance(outfile, unicode):
             dstfile = io.open(outfile, 'w', encoding='utf-8')
         else:
             dstfile = outfile
-        
-        
         srt_i = 1
         for i, (timestamp, content) in enumerate(rendered_grouped[:-1]):
             if content == '':

--- a/resources/lib/ttml2srt.py
+++ b/resources/lib/ttml2srt.py
@@ -27,205 +27,223 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+#Latest commit 2c361b5 on 29 Sep 2018
 
 import re
 import io
 
 from datetime import timedelta
-from defusedxml import ElementTree as ET
+from xml.etree import ElementTree as ET
 
+class ttml2srt(object):
 
-def ttml2srt(infile, outfile):
-    """
-    Conversion routine for subtitle files from
-    TTML to SRT
-
-    Args:
-        infile(str): full name of the input file
-
-        outfile(str): full name of the converted file
-    """
-    tree = ET.parse(infile)
-    root = tree.getroot()
-
-    # strip namespaces
-    for elem in root.getiterator():
-        elem.tag = elem.tag.split('}', 1)[-1]
-        elem.attrib = {name.split('}', 1)
-                       [-1]: value for name, value in list(elem.attrib.items())}
-
-    # get styles
-    styles = {}
-    for elem in root.findall('./head/styling/style'):
-        style = {}
-        if 'color' in elem.attrib:
-            color = elem.attrib['color']
-            if color not in ('#FFFFFF', '#000000'):
-                style['color'] = color
-        if 'fontStyle' in elem.attrib:
-            fontstyle = elem.attrib['fontStyle']
-            if fontstyle in ('italic', ):
-                style['fontstyle'] = fontstyle
-        styles[elem.attrib['id']] = style
-
-    body = root.find('./body')
-
-    # parse correct start and end times
-    def _parse_time_expression(expression, default_offset=timedelta(0)):
-        offset_time = re.match(
-            r'^([0-9]+(\.[0-9]+)?)(h|m|s|ms|f|t)$', expression)
-        if offset_time:
-            time_value, _, metric = offset_time.groups()
-            time_value = float(time_value)
-            if metric == 'h':
-                return default_offset + timedelta(hours=time_value)
-            elif metric == 'm':
-                return default_offset + timedelta(minutes=time_value)
-            elif metric == 's':
-                return default_offset + timedelta(seconds=time_value)
-            elif metric == 'ms':
-                return default_offset + timedelta(milliseconds=time_value)
-            elif metric == 'f':
-                raise NotImplementedError(
-                    'Parsing time expressions by frame is not supported!')
-            elif metric == 't':
-                raise NotImplementedError(
-                    'Parsing time expressions by ticks is not supported!')
-
-        clock_time = re.match(
-            r'^([0-9]{2,}):([0-9]{2,}):([0-9]{2,}(\.[0-9]+)?)$', expression)
-        if clock_time:
-            hours, minutes, seconds, _ = clock_time.groups()
-            return timedelta(hours=int(hours), minutes=int(minutes), seconds=float(seconds))
-
-        clock_time_frames = re.match(
-            r'^([0-9]{2,}):([0-9]{2,}):([0-9]{2,}):([0-9]{2,}(\.[0-9]+)?)$', expression)
-        if clock_time_frames:
-            raise NotImplementedError(
-                'Parsing time expressions by frame is not supported!')
-
-        raise ValueError('unknown time expression: %s' % expression)
-
-    def _parse_times(elem, default_begin=timedelta(0)):
-        if 'begin' in elem.attrib:
-            begin = _parse_time_expression(
-                elem.attrib['begin'], default_offset=default_begin)
-        else:
-            begin = default_begin
-        elem.attrib['{abs}begin'] = begin
-
-        end = None
-        if 'end' in elem.attrib:
-            end = _parse_time_expression(
-                elem.attrib['end'], default_offset=default_begin)
-
-        dur = None
-        if 'dur' in elem.attrib:
-            dur = _parse_time_expression(elem.attrib['dur'])
-
-        if dur is not None:
-            if end is None:
-                end = begin + dur
+    def __init__(self):
+        self.styles = {}
+        
+    def do(self, infile, outfile):
+        """
+        Conversion routine for subtitle files from
+        TTML to SRT
+    
+        Args:
+            infile(str): full name of the input file
+    
+            outfile(str): full name of the converted file
+        """
+        tree = ET.parse(infile)
+        root = tree.getroot()
+        
+        # strip namespaces
+        for elem in root.getiterator():
+            elem.tag = elem.tag.split('}', 1)[-1]
+            elem.attrib = {name.split('}', 1)[-1]: value for name, value in elem.attrib.items()}
+        
+        tick_rate = root.attrib.get('tickRate', None)
+        if tick_rate is not None:
+            tick_rate = int(tick_rate)
+        
+        # get styles
+        self.styles = {}
+        for elem in root.findall('./head/styling/style'):
+            style = {}
+            if 'color' in elem.attrib:
+                color = elem.attrib['color']
+                if color not in ('#FFFFFF', '#000000'):
+                    style['color'] = color
+            if 'fontStyle' in elem.attrib:
+                fontstyle = elem.attrib['fontStyle']
+                if fontstyle in ('italic', ):
+                    style['fontstyle'] = fontstyle
+            self.styles[elem.attrib['id']] = style
+        
+        body = root.find('./body')
+        # parse correct start and end times
+        def _parse_time_expression(expression, default_offset=timedelta(0)):
+            offset_time = re.match(r'^([0-9]+(\.[0-9]+)?)(h|m|s|ms|f|t)$', expression)
+            if offset_time:
+                time_value, fraction, metric = offset_time.groups()
+                time_value = float(time_value)
+                if metric == 'h':
+                    return default_offset + timedelta(hours=time_value)
+                elif metric == 'm':
+                    return default_offset + timedelta(minutes=time_value)
+                elif metric == 's':
+                    return default_offset + timedelta(seconds=time_value)
+                elif metric == 'ms':
+                    return default_offset + timedelta(milliseconds=time_value)
+                elif metric == 'f':
+                    raise NotImplementedError('Parsing time expressions by frame is not supported!')
+                elif metric == 't':
+                    if tick_rate is None:
+                        raise NotImplementedError('Time expression contains ticks but tickRate is not specified!')
+                    return default_offset + timedelta(seconds=time_value/tick_rate)
+        
+            clock_time = re.match(r'^([0-9]{2,}):([0-9]{2,}):([0-9]{2,}(\.[0-9]+)?)$', expression)
+            if clock_time:
+                hours, minutes, seconds, fraction = clock_time.groups()
+                return timedelta(hours=int(hours), minutes=int(minutes), seconds=float(seconds))
+        
+            clock_time_frames = re.match(r'^([0-9]{2,}):([0-9]{2,}):([0-9]{2,}):([0-9]{2,}(\.[0-9]+)?)$', expression)
+            if clock_time_frames:
+                raise NotImplementedError('Parsing time expressions by frame is not supported!')
+        
+            raise ValueError('unknown time expression: %s' % expression)
+        
+        def _parse_times(elem, default_begin=timedelta(0)):
+            if 'begin' in elem.attrib:
+                begin = _parse_time_expression(elem.attrib['begin'], default_offset=default_begin)
             else:
-                end = min(end, begin + dur)
-
-        elem.attrib['{abs}end'] = end
-
-        for child in elem:
-            _parse_times(child, default_begin=begin)
-
-    _parse_times(body)
-
-    timestamps = set()
-    for elem in body.findall('.//*[@{abs}begin]'):
-        timestamps.add(elem.attrib['{abs}begin'])
-
-    for elem in body.findall('.//*[@{abs}end]'):
-        timestamps.add(elem.attrib['{abs}end'])
-
-    timestamps.discard(None)
-
-    # render subtitles on each timestamp
-
-    def _render_subtitles(elem, timestamp, parent_style=None):
-
-        if timestamp < elem.attrib['{abs}begin']:
-            return ''
-        if elem.attrib['{abs}end'] is not None and timestamp >= elem.attrib['{abs}end']:
-            return ''
-
-        result = ''
-
-        style = parent_style.copy() if parent_style is not None else {}
-        if 'style' in elem.attrib:
-            style.update(styles[elem.attrib['style']])
-
-        if 'color' in style:
-            result += '<font color="%s">' % style['color']
-
-        if style.get('fontstyle') == 'italic':
-            result += '<i>'
-
-        if elem.text:
-            result += elem.text.strip()
-        if elem is not None:
+                begin = default_begin
+            elem.attrib['{abs}begin'] = begin
+        
+            end = None
+            if 'end' in elem.attrib:
+                end = _parse_time_expression(elem.attrib['end'], default_offset=default_begin)
+        
+            dur = None
+            if 'dur' in elem.attrib:
+                dur = _parse_time_expression(elem.attrib['dur'])
+        
+            if dur is not None:
+                if end is None:
+                    end = begin + dur
+                else:
+                    end = min(end, begin + dur)
+        
+            elem.attrib['{abs}end'] = end
+        
             for child in elem:
-                result += _render_subtitles(child, timestamp)
-                if child.tail:
-                    result += child.tail.strip()
-
-        if 'color' in style:
-            result += '</font>'
-
-        if style.get('fontstyle') == 'italic':
-            result += '</i>'
-
-        if elem.tag in ('div', 'p', 'br'):
-            result += '\n'
-
-        return result
-
-    rendered = []
-    for timestamp in sorted(timestamps):
-        rendered.append((timestamp, re.sub(r'\n\n\n+', '\n\n',
-                                           _render_subtitles(body, timestamp)).strip()))
-
-    if not rendered:
-        exit(0)
-
-    # group timestamps together if nothing changes
-    rendered_grouped = []
-    last_text = None
-    for timestamp, content in rendered:
-        if content != last_text:
-            rendered_grouped.append((timestamp, content))
-        last_text = content
-
-    # output srt
-    rendered_grouped.append(
-        (rendered_grouped[-1][0] + timedelta(hours=24), ''))
-
-    def _format_timestamp(timestamp):
-        return ('%02d:%02d:%02.3f' % (timestamp.total_seconds() // 3600,
-                                      timestamp.total_seconds() // 60 % 60,
-                                      timestamp.total_seconds() % 60)).replace('.', ',')
-
-    if isinstance(outfile, str) or isinstance(outfile, unicode):
-        dstfile = io.open(outfile, 'w', encoding='utf-8')
-    else:
-        dstfile = outfile
-
-    srt_i = 1
-    for i, (timestamp, content) in enumerate(rendered_grouped[:-1]):
-        if content == '':
-            continue
-        dstfile.write(bytearray('%d\n' % srt_i, 'utf-8'))
-        dstfile.write(bytearray(
-            _format_timestamp(timestamp) +
-            ' --> ' +
-            _format_timestamp(rendered_grouped[i + 1][0]) +
-            '\n'
-        ))
-        dstfile.write(bytearray(content + '\n\n', 'utf-8'))
-        srt_i += 1
-    dstfile.close()
+                _parse_times(child, default_begin=begin)
+        
+        _parse_times(body)
+        timestamps = set()
+        for elem in body.findall('.//*[@{abs}begin]'):
+            timestamps.add(elem.attrib['{abs}begin'])
+        
+        for elem in body.findall('.//*[@{abs}end]'):
+            timestamps.add(elem.attrib['{abs}end'])
+        
+        timestamps.discard(None)
+        # render subtitles on each timestamp
+        def _render_subtitles(elem, timestamp, parent_style={}):
+        
+            if timestamp < elem.attrib['{abs}begin']:
+                return ''
+            if elem.attrib['{abs}end'] is not None and timestamp >= elem.attrib['{abs}end']:
+                return ''
+        
+            result = ''
+        
+            style = parent_style.copy()
+            if 'style' in elem.attrib:
+                style.update(self.styles[elem.attrib['style']])
+        
+            if 'color' in elem.attrib:
+                style['color'] = elem.attrib['color']
+        
+            if 'fontStyle' in elem.attrib:
+                style['fontstyle'] = elem.attrib['fontStyle']
+        
+            if 'color' in style:
+                result += '<font color="%s">' % style['color']
+        
+            if style.get('fontstyle') == 'italic':
+                result += '<i>'
+        
+            if elem.text:
+                #result += elem.text.strip()
+                result += re.sub(r'\s+$', ' ', re.sub(r'^\s+', ' ', elem.text))
+            if len(elem):
+                for child in elem:
+                    result += _render_subtitles(child, timestamp)
+                    if child.tail:
+                        result += re.sub(r'\s+$', ' ', re.sub(r'^\s+', ' ', child.tail))
+        
+            result_stripped = result #.rstrip()
+            trailing_whitespaces = result[len(result_stripped):]
+            result = result_stripped
+        
+            if 'color' in style:
+                result += '</font>'
+        
+            if style.get('fontstyle') == 'italic':
+                result += '</i>'
+        
+            result += trailing_whitespaces
+        
+            result = re.sub(r'(?P<all>(\s|^)<(font color="([^"]+)"|i)>) +', '\g<all>', result)
+            result = re.sub(r' +(?P<all></(font|i)>(\s|$))', '\g<all>', result)
+            result = re.sub(r'\n\s+', '\n', result)
+            result = re.sub(r'\s+\n', '\n', result)
+        
+            result = re.sub(r'<font color="(?P<color1>[^"]+)">(?P<startspaces>\s*)<font color="(?P<color2>[^"]+)">(?P<text>[^<]+)</font>(?P<endspaces>\s*)</font>',
+                            r'\g<startspaces><font color="\g<color2>">\g<text></font>\g<endspaces>',
+                            result)
+        
+            result = re.sub(r'\n+(?P<all></(font|i)>)', '\g<all>\n', result)
+        
+            result = re.sub(r'<font color="([^"]+)">(?P<spaces>\s*)</font>', '\g<spaces>', result)
+        
+            if elem.tag in ('div', 'p', 'br'):
+                result += '\n'
+        
+            return result
+        
+        rendered = []
+        for timestamp in sorted(timestamps):
+            rendered.append((timestamp, re.sub(r'\n\n\n+', '\n\n', _render_subtitles(body, timestamp)).strip()))
+        
+        if not rendered:
+            exit(0)
+        
+        # group timestamps together if nothing changes
+        rendered_grouped = []
+        last_text = None
+        for timestamp, content in rendered:
+            if content != last_text:
+                rendered_grouped.append((timestamp, content))
+            last_text = content
+        
+        # output srt
+        rendered_grouped.append((rendered_grouped[-1][0]+timedelta(hours=24), ''))
+        
+        def _format_timestamp(timestamp):
+            return ('%02d:%02d:%06.3f' % (timestamp.total_seconds()//3600,
+                                          timestamp.total_seconds()//60%60,
+                                          timestamp.total_seconds()%60)).replace('.', ',')
+        
+        if isinstance(outfile, str) or isinstance(outfile, unicode):
+            dstfile = io.open(outfile, 'w', encoding='utf-8')
+        else:
+            dstfile = outfile
+        
+        
+        srt_i = 1
+        for i, (timestamp, content) in enumerate(rendered_grouped[:-1]):
+            if content == '':
+                continue
+            dstfile.write(bytearray('%d\n' % srt_i, 'utf-8'))
+            dstfile.write(bytearray(_format_timestamp(timestamp) + ' --> ' + _format_timestamp(rendered_grouped[i + 1][0]) + '\n'))
+            dstfile.write(bytearray(content + '\n\n', 'utf-8'))
+            srt_i += 1
+        dstfile.close()


### PR DESCRIPTION
Abhängigkeit zu defusedXml lib entfernt. Die lib wurde nur verwendet um die Untertitel mit einer weiteren 3rd party lib zu konvertierten. Diese lib habe ich auf mit der neuesten Version ersetzt (Phyton 3 kompat). Dort wird defusedXml nicht mehr verwendet und dann weg.
Das diff von ttml2srt sieht schlimmer aus als es ist...
Nach dem Change sieht das Untertitel leicht verändert aus:
* Datum / Uhr zeit: Vorher ohne führende 0 z.B. 20:03.5 > nach dem Change > 20:03:05
* Es gibt ein paar space mehr z.B. "[...]</elementA><elementB>" > nach dem Change > [...]</elementA> <elementB> 