### PR TITLE
[WIP] Use server time for checking update necessity (full/interval)

### DIFF
--- a/resources/lib/mvutils.py
+++ b/resources/lib/mvutils.py
@@ -22,6 +22,8 @@ except ImportError:
     from urllib import urlencode
     from urllib2 import urlopen
 
+from email.utils import parsedate_tz, mktime_tz
+
 from contextlib import closing
 from resources.lib.exceptions import ExitRequested
 
@@ -178,6 +180,15 @@ def cleanup_filename(val):
     search = ''.join([c for c in val if c in cset])
     return search.strip()
 
+def url_lastmodified(url):
+    """
+    Query a network object's last-modified value as a unix timestamp
+
+    Args:
+        url(str): the source url of the object to query
+    """
+    with closing(urlopen(url)) as src:
+        return mktime_tz(parsedate_tz(src.info().get('last-modified')))
 
 def url_retrieve(url, filename, reporthook, chunk_size=8192, aborthook=None):
     """

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -22,7 +22,7 @@
 		<setting id="updnative"			type="bool"		label="30233"	default="true"				visible="eq(-6,0)"		/>
 		<setting id="caching"			type="bool"		label="30234"	default="true"				visible="eq(-7,0)"		/>
 		<setting id="updmode"			type="enum"		label="30231"	default="3"	lvalues="30241|30242|30243|30244|30245"	/>
-		<setting id="updinterval"		type="slider"	label="30232"	default="2"	range="1,24"	visible="gt(-1,2)"		/>
+		<setting id="updinterval"		type="slider"	label="30232"	default="1"	range="1,24"	visible="gt(-1,2)"		/>
 	</category>
 	<category label="30003">
 		<setting id="downloadpathep"	type="folder"	label="30310"	source="auto"	option="writeable"					/>


### PR DESCRIPTION
Auszug aus dem Log des Standalone-mvupdate (noch vor #163, also „Version 0.0“):
```
May 02 01:00:58 nas python3[32280]: 2020-05-02 01:00:58.314331 DEBUG [mvupdate-0.0:MediathekViewUpdater]: Last update was not today. do full update once a day
…
May 02 01:01:38 nas python3[32280]: 2020-05-02 01:01:38.283545 NOTICE [mvupdate-0.0:MediathekViewUpdater]: Filmliste dated 01.05.2020, 23:31
```
Danach gab es dann nur noch Diffs und ich glaube, das ist der Grund, warum ich heute Morgen nicht die aktuellen Tagesthemen im MediathekView-Addon hatte.
Die PR sollte das beheben, indem nun nicht mehr das aktuelle Datum und das Datum des letzten Updates, sondern das ungefähre* Datum der letzten Änderung der Online-Filmliste und das Datum des letzten Updates der lokalen Filmliste verglichen wird, um ein volles Update anzustoßen.
In Fällen mit schlechtem Timing* könnten nun unnötige Vollupdates gefahren werden, aber die meisten Nutzer werden vermutlich eh erst ein Update fahren, wenn sie das Addon zum ersten Mal an einem gegebenen Tag anschmeißen.
*: Die Last-Modified-Zeit ist immer ungefähr eine Viertelstunde nach der echten Filmlisten-Zeit. Wird also ein Filmlisten-Crawl um 23:55 Uhr gestartet und um 0:10 Uhr veröffentlicht (last modified), würde `mvupdate` um bspw. 1:00 Uhr ein Vollupdate fahren und das `mvupdate` um 3:00 Uhr (oder 4:00 Uhr) wäre dann wieder ein Vollupdate. Es würden aber zu keinem Zeitpunkt unnötig Sendungen in der lokalen Datenbank fehlen. Die Tagesthemen hat man dann ggf. bis zum Ende des Vier-Uhr-Updates nicht, aber das wäre ja ohnehin passiert. Wenn man so früh Tagesthemen schauen möchte, muss man wohl in jedem Fall rechtzeitig einen Vollupdate-Wecker stellen. :)