### PR TITLE
Movie-Counter für storemysql.py wiederhergestellt

### DIFF
--- a/resources/lib/storemysql.py
+++ b/resources/lib/storemysql.py
@@ -1001,7 +1001,7 @@ DROP TEMPORARY TABLE IF EXISTS `t_film`;
         if commit:
             cursor = self.conn.cursor()
             try:
-                for _ in cursor.execute(self.sql_films_prepareTT, multi=True): pass
+                for result in cursor.execute(self.sql_films_prepareTT, multi=True): pass
 
                 if len(self.films_to_insert) == 1:
                     # For single row inserts use execute instead of executemany
@@ -1011,7 +1011,10 @@ DROP TEMPORARY TABLE IF EXISTS `t_film`;
                 else :
                     cursor.executemany(self.sql_films_insertTT, self.films_to_insert)
 
-                for _ in cursor.execute(self.sql_films_process, multi=True): pass
+                for result in cursor.execute(self.sql_films_process, multi=True):
+                    if not result.with_rows:
+                        if result.statement.startswith("INSERT INTO `film`"):
+                            insmov = result.rowcount
 
                 self.films_to_insert = []
             except mysql.connector.Error as err:
@@ -1028,7 +1031,7 @@ DROP TEMPORARY TABLE IF EXISTS `t_film`;
                     # because it has to be emptyed for this process.
                     _rows = []
                     for row in self.films_to_insert:
-                        _rows.append(row)
+                        insmov += _rows.append(row)[3]
 
                     self.films_to_insert = []
 

--- a/resources/lib/storemysql.py
+++ b/resources/lib/storemysql.py
@@ -1008,10 +1008,8 @@ DROP TEMPORARY TABLE IF EXISTS `t_film`;
                     # in hope of failing single row inserts give us more detailed
                     # feedback about a violating value.
                     cursor.execute(self.sql_films_insertTT, self.films_to_insert[0])
-                    insmov = insmov + 1
                 else :
                     cursor.executemany(self.sql_films_insertTT, self.films_to_insert)
-                    insmov = insmov + len(self.films_to_insert)
 
                 for result in cursor.execute(self.sql_films_process, multi=True):
                     if not result.with_rows:


### PR DESCRIPTION
Ich nehme an, du willst nur die tatsächlich neu eingefügten Filme zählen. Das kann der Fix aus aaa045ccd12674 nicht leisten, der zählte denke ich alle File die in die temp. Tabelle für den Abgleich geladen wurden. Also auch alle bereits vorhandenen Filme mit.

Hier ein Fix, der nur die neu in film eingefügten File zählt.