### PR TITLE
Updater now forces commit on last dataset processed.

### DIFF
--- a/resources/lib/updater.py
+++ b/resources/lib/updater.py
@@ -531,7 +531,7 @@ class MediathekViewUpdater(object):
         self.film["geo"] = ""
 
     def _end_record(self, records):
-        if self.count % 1000 == 0:
+        if self.count % 1000 == 0 or self.count == records:
             # pylint: disable=line-too-long
             percent = int(self.count * 100 / records)
             self.logger.info('In progress (%d%%): channels:%d, shows:%d, movies:%d ...' % (


### PR DESCRIPTION
Schau mal ob das funktioniert. Der Updater muss denke ich in jedem Fall (unabhängig von Backend) den letzten Datensatz mit commit=true einfügen. Sonst kann es immer das Problem geben, dass die letzten Datensätze verloren gehen. Zumindest dann wenn das Backend tatsächlich eine Transaktion aufspannt.