### PR TITLE
Docker build schlägt fehl wegen PEP-668 - Marking Python base environments as “externally managed”

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,12 @@ ENV RUN_ON_STARTUP='no'
 
 # install dependencies
 RUN apk update && apk upgrade && \
-    apk add py3-pip apk-cron vim sqlite && \
+    apk add py3-virtualenv py3-pip apk-cron vim sqlite && \
     rm -rf /var/cache/apk/*
+
+# create Python virtual environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 RUN pip3 install mysql-connector-python
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.mediathekview"
 	name="MediathekView"
-	version="1.0.15"
+	version="1.1.0"
 	provider-name="MediathekView.de, Leo Moll">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>

--- a/resources/lib/updater.py
+++ b/resources/lib/updater.py
@@ -145,11 +145,14 @@ class MediathekViewUpdater(object):
                 self.logger.debug('full update')
                 if (not(mvutils.file_exists(os.path.join(self.settings.getDatapath() , 'Filmliste-akt')))): 
                     ufd.downloadFullUpdateFile()
+                    downloadFullUpdate = True
                 else:
                     ufd._filename = os.path.join(self.settings.getDatapath() , 'Filmliste-akt')
                     self.logger.debug('use existing full update file')
+                    downloadFullUpdate = False
                 UpdateFileImport(ufd.getTargetFilename(), self.database).updateFull()
-                ufd.removeDownloads()
+                if (downloadFullUpdate):
+                    ufd.removeDownloads()
                 #
                 self.database.set_status('IDLE', pLastupdate=int(time.time()), pLastFullUpdate=int(time.time()))
                 #


### PR DESCRIPTION
PEP-668 markiert Python Basis Installationen als "externally managed".
Diese Meldung führt zum Abbruch des Docker Builds. Durch anlegen eines Python virtual environments im Docker Image wird das Problem behoben.
Siehe auch [PEP-668](https://peps.python.org/pep-0668/) und die passende Stackoverflow-Antwort: https://stackoverflow.com/questions/75602063/pip-install-r-requirements-txt-is-failing-this-environment-is-externally-mana/75696359#75696359.
