### PR TITLE
JSON-Parsing Fehler bei Verwendung von MySQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 RUN pip3 install mysql-connector-python
+RUN pip3 install simplejson
 
 #cop mediathekview plugin
 WORKDIR /plugin.video.mediathekview

--- a/addon.xml
+++ b/addon.xml
@@ -6,6 +6,7 @@
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.myconnpy" version="1.1.7"/>
+		<import addon="script.module.simplejson" version="3.16.1"/>
 	</requires>
 	<extension
 		point="xbmc.python.pluginsource"

--- a/resources/lib/extendedSearch.py
+++ b/resources/lib/extendedSearch.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 """
 
 import os
-import json
+import simplejson as json
 import time
 import resources.lib.appContext as appContext
 import resources.lib.extendedSearchModel as ExtendedSearchModel

--- a/resources/lib/mvutils.py
+++ b/resources/lib/mvutils.py
@@ -13,7 +13,7 @@ import re
 import sys
 import stat
 import string
-import json
+import simplejson as json
 import datetime
 from contextlib import closing
 from codecs import open

--- a/resources/lib/searches.py
+++ b/resources/lib/searches.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 """
 
 import os
-import json
+import simplejson as json
 import time
 import resources.lib.appContext as appContext
 

--- a/resources/lib/storeCache.py
+++ b/resources/lib/storeCache.py
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 # pylint: disable=too-many-lines,line-too-long
 
 import os
-import json
+import simplejson as json
 import time
 
 import resources.lib.appContext as appContext

--- a/resources/lib/ui/filmlistUi.py
+++ b/resources/lib/ui/filmlistUi.py
@@ -121,10 +121,10 @@ class FilmlistUi(object):
         }
 
         if pFilm.seconds is not None and pFilm.seconds > 0:
-            info_labels['duration'] = pFilm.seconds
+            info_labels['duration'] = float(pFilm.seconds)
 
         if pFilm.aired is not None and pFilm.aired != 0:
-            ndate = self.tzBase + timedelta(seconds=(pFilm.aired))
+            ndate = self.tzBase + timedelta(seconds=float(pFilm.aired))
             airedstring = ndate.isoformat().replace('T', ' ')
             info_labels['date'] = airedstring[:10]
             info_labels['aired'] = airedstring[:10]

--- a/resources/lib/updateFileImport.py
+++ b/resources/lib/updateFileImport.py
@@ -17,7 +17,7 @@ import resources.lib.appContext as appContext
 from contextlib import closing
 from codecs import open
 
-import json
+import simplejson as json
 
 import resources.lib.mvutils as mvutils
 

--- a/resources/lib/updateFileParser.py
+++ b/resources/lib/updateFileParser.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
 """
 
 # -- Imports ------------------------------------------------
-import json
+import simplejson as json
 from contextlib import closing
 from codecs import open
 


### PR DESCRIPTION
Hi @codingPF ,

Python _myconnpy_ liest in der aktuellen Version die Ausstrahlungszeitpunkte und Laufzeiten als Python-Datentyp _decimal.Decimal_ aus. Das führt zu mehreren Folgefehlern bei der weiteren Verarbeitung dieser Werte im Kodi-Plugin.
Die Python Standard Bibliothek _json_ unterstützt _decimal.Decimal_ nicht ohne Weiteres:
```
EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--                                                                                                        
    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!                                                                                                        
     Error Type: <class 'TypeError'>                                                                                                                         
     Error Contents: Object of type Decimal is not JSON serializable                                                                                         
     Traceback (most recent call last):                                                                                                                      
       File "/home/dietpi/.kodi/addons/plugin.video.mediathekview/addon.py", line 26, in <module>                                                            
         PLUGIN.run()                                                                                                                                        
       File "/home/dietpi/.kodi/addons/plugin.video.mediathekview/resources/lib/plugin.py", line 214, in run                                                 
         ui.generate(self.database.getFilms(channel, show))                                                                                                  
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                   
       File "/home/dietpi/.kodi/addons/plugin.video.mediathekview/resources/lib/storeQuery.py", line 278, in getFilms                                        
         self._cache.save_cache('films', cacheKey, rs)                                                                                                       
       File "/home/dietpi/.kodi/addons/plugin.video.mediathekview/resources/lib/storeCache.py", line 98, in save_cache                                       
         json.dump(cache, json_file)                                                                                                                         
       File "/usr/lib/python3.11/json/__init__.py", line 179, in dump                                                                                        
         for chunk in iterable:                                                                                                                              
       File "/usr/lib/python3.11/json/encoder.py", line 432, in _iterencode                                                                                  
         yield from _iterencode_dict(o, _current_indent_level)                                                                                               
       File "/usr/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict                                                                             
         yield from chunks                                                                                                                                   
       File "/usr/lib/python3.11/json/encoder.py", line 326, in _iterencode_list                                                                             
         yield from chunks                                                                                                                                   
       File "/usr/lib/python3.11/json/encoder.py", line 326, in _iterencode_list                                                                             
         yield from chunks                                                                                                                                   
       File "/usr/lib/python3.11/json/encoder.py", line 439, in _iterencode                                                                                  
         o = _default(o)                                                                                                                                     
             ^^^^^^^^^^^                                                                                                                                     
       File "/usr/lib/python3.11/json/encoder.py", line 180, in default                                                                                      
         raise TypeError(f'Object of type {o.__class__.__name__} '                                                                                           
     TypeError: Object of type Decimal is not JSON serializable                                                                                              
     -->End of Python script error report<--                        
```
Mit diesem Commit wird Python _simplejson_ statt _json_ verwendet - _simplejson_ unterstützt _decimal.Decimal_ [out of the box](https://stackoverflow.com/a/3148376).
Bei der Erstellung der UI-Listenelemente werden dann die _decimal.Decimal_ Werte in _float_ konvertiert, damit die weitere automatische Konvertierung zu String-Werten funktioniert. Folgender Aufruf schlägt sonst fehl:
https://github.com/mediathekview/plugin.video.mediathekview/blob/3e4fa90a87c2652f3b0745e55fb0e14f6863da24/resources/lib/ui/filmlistUi.py#L155

Ich habe den Fix mit einem neuen Docker Build und Kodi 20 (Nexus) getestet. Außerdem habe ich die Verwendung einer lokalen SQLite-Datenbank mit den Änderungen getestet.

Wenn etwas nicht passt, sag gern Bescheid, damit ich es korrigieren kann.

Cheers :beers: 